### PR TITLE
Remove jsx-a11y and react eslint plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,12 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 React specific rules were removed. Use `eslint-pluin-react` instead.
 
-* [#1](https://github.com/rearjs/eslint-config-rear/pull/1) Remove `eslint-plugin-jsx-a11y`
-* [#1](https://github.com/rearjs/eslint-config-rear/pull/1) Remove `eslint-plugin-react`
+* #1 Remove `eslint-plugin-jsx-a11y`
+* #1 Remove `eslint-plugin-react`
+
+#### :house: Internal
+
+* #2 Remove `eslint-plugin-jsx-a11y` and `eslint-plugin-react` peer dependencies
 
 #### :house: Internal
 

--- a/package.json
+++ b/package.json
@@ -13,8 +13,5 @@
     "babel-eslint": "^7.2.3",
     "eslint": "^3.19.0",
     "eslint-plugin-flowtype": "^2.33.0",
-    "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-jsx-a11y": "^5.0.3",
-    "eslint-plugin-react": "^7.0.1"
-  }
+    "eslint-plugin-import": "^2.2.0"
 }


### PR DESCRIPTION
`package.json` should be updated to reflect the changes in rules requirements.